### PR TITLE
fixed option passing in executable

### DIFF
--- a/among-us-dumpy-gif-maker
+++ b/among-us-dumpy-gif-maker
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-/usr/lib/jvm/java-15-openjdk/bin/java -jar /usr/lib/Among-Us-Dumpy-Gif-Maker-2.0.2-all.jar
+/usr/lib/jvm/java-15-openjdk/bin/java -jar /usr/lib/Among-Us-Dumpy-Gif-Maker-2.0.2-all.jar $1 $2


### PR DESCRIPTION
When I downloaded this program from the AUR, options weren't passing. I would run `among-us-dumpy-gif-maker 50 ./picture.png` and it would still give me a prompt to select a file and the output would be 9 lines. I just added two flags in the executable that allow for optional argument passing.